### PR TITLE
modified the imap library to account for extra padding in davmail

### DIFF
--- a/getmailcore/_retrieverbases.py
+++ b/getmailcore/_retrieverbases.py
@@ -497,6 +497,7 @@ class IMAPinitMixIn(object):
     '''Mix-In class to do IMAP non-SSL initialization.
     '''
     SSL = False
+    imaplib.Untagged_status = imaplib.re.compile(br'\*[ ]{1,2}(?P<data>\d+) (?P<type>[A-Z-]+)( (?P<data2>.*))?')
     def _connect(self):
         self.log.trace()
         try:


### PR DESCRIPTION
When working with davmail additional whitespaces can be added to the `EXISTS` response. Additional regex accounts for the whitespaces and continues to process without exception.